### PR TITLE
Reformats imports for the fact that AFNetworking is now a framework.

### DIFF
--- a/DZWebDAVClient/DZDictionaryRequestOperation.h
+++ b/DZWebDAVClient/DZDictionaryRequestOperation.h
@@ -8,7 +8,7 @@
 //  Licensed under MIT. See LICENSE.
 //
 
-#import "AFXMLRequestOperation.h"
+@import AFNetworking.AFXMLRequestOperation;
 
 /**
  `DZDictionaryRequestOperation` is a subclass of `AFXMLRequestOperation` for downloading and working with XML response data as an NSDictionary.

--- a/DZWebDAVClient/DZWebDAVClient.h
+++ b/DZWebDAVClient/DZWebDAVClient.h
@@ -8,7 +8,7 @@
 //  Licensed under MIT. See LICENSE.
 //
 
-#import "AFHTTPClient.h"
+@import AFNetworking.AFHTTPClient;
 
 /** The key for a uniform (MIME) type identifier returned from the property request methods. */
 extern NSString *DZWebDAVContentTypeKey;


### PR DESCRIPTION
This PR is needed as part of when the `MTFoundation` branch `jv-refactor-service` is finally merged into `master`.
